### PR TITLE
Fix info directory entry.

### DIFF
--- a/folding.texi
+++ b/folding.texi
@@ -17,7 +17,7 @@
 
 @dircategory Emacs
 @direntry
-* folding: folding editor minor mode for Emacs
+* Folding: (folding).  Folding editor minor mode for Emacs.
 @end direntry
 
 @node Top, folding Installation, (dir), (dir)


### PR DESCRIPTION
Info expects the directory entry format:

  * ENTRY: (FILE)[NODE].  DESCRIPTION

and doesn't render the current entry format as an info reference in a
directory file.  It additionally causes install-info to produce corrupted
`dir' files (separate bug* sent to texinfo).

*https://lists.gnu.org/archive/html/bug-texinfo/2021-11/msg00003.html